### PR TITLE
chore: ignore ubuntu base image renovate updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.sh text eol=lf
 *.shellcheckrc text eol=lf
+Dockerfile text eol=lf

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "schedule:weekly",
     "helpers:pinGitHubActionDigests"
   ],
+  "ignoreDeps": ["docker.io/library/ubuntu"],
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],


### PR DESCRIPTION
[skip ci]